### PR TITLE
Update exception syntax to work with Python 3

### DIFF
--- a/loadmovr.py
+++ b/loadmovr.py
@@ -90,7 +90,7 @@ def simulate_movr_load(conn_string, cities, movr_objects, active_rides, read_per
                         ride = active_rides.pop()
                         movr.end_ride(ride['city'], ride['id'])
                 num_retries = 0
-            except Exception, e: #@todo: catch the right exception
+            except Exception as e: #@todo: catch the right exception
                 num_retries += 1
                 exception_message = str(e)
                 logging.debug("Retry attempt %d, last attempt failed with %s", num_retries, exception_message)


### PR DESCRIPTION
This was the only syntactic issue causing an issue for Python 3.7.1.
When loaded it would fail with the following:

    $ python3 loadmovr.py load
      File "loadmovr.py", line 93
        except Exception, e: #@todo: catch the right exception
                        ^
    SyntaxError: invalid syntax