### PR TITLE
Capture client-side transaction stats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/src/app
 COPY loadmovr.py ./
 COPY models.py ./
 COPY movr.py ./
+COPY movr_stats.py ./
 COPY generators.py ./
 COPY requirements.txt ./
 

--- a/loadmovr.py
+++ b/loadmovr.py
@@ -92,7 +92,7 @@ def simulate_movr_load(conn_string, cities, movr_objects, active_rides, read_per
                 # simulate user loading screen
                 start = time.time()
                 movr.get_vehicles(active_city,25)
-                stats.add_latency_measurement("loading_screen",time.time() - start )
+                stats.add_latency_measurement("get vehicles",time.time() - start )
 
             else:
 
@@ -394,7 +394,7 @@ def run_load_generator(conn_string, read_percentage, city_list, echo_sql, num_th
         RUNNING_THREADS.append(t)
 
     while True: #keep main thread alive to catch exit signals
-        time.sleep(5)
+        time.sleep(10)
         stats.print_stats()
         stats.new_window()
 

--- a/loadmovr.py
+++ b/loadmovr.py
@@ -11,6 +11,8 @@ from cockroachdb.sqlalchemy import run_transaction
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine
 from urllib.parse import parse_qs, urlsplit, urlunsplit, urlencode
+from movr_stats import MovRStats
+
 
 RUNNING_THREADS = []
 TERMINATE_GRACEFULLY = False
@@ -31,6 +33,10 @@ def signal_handler(sig, frame):
 
     logging.info("shutting down gracefully.")
     sys.exit(0)
+
+
+
+
 
 
 
@@ -84,21 +90,29 @@ def simulate_movr_load(conn_string, cities, movr_objects, active_rides, read_per
 
             if random.random() < read_percentage:
                 # simulate user loading screen
+                start = time.time()
                 movr.get_vehicles(active_city,25)
+                stats.add_latency_measurement("loading_screen",time.time() - start )
+
             else:
 
                 # every write tick, simulate the various vehicles updating their locations if they are being used for rides
                 for ride in active_rides:
+                    start = time.time()
                     latlong = MovRGenerator.generate_random_latlong()
                     movr.update_ride_location(ride['city'], ride_id=ride['id'], lat=latlong['lat'],
                                               long=latlong['long'])
+                    stats.add_latency_measurement("update ride location", time.time() - start)
 
                 #do write operations randomly
                 if random.random() < .1:
                     # simulate new signup
+                    start = time.time()
                     movr_objects[active_city]["users"].append(movr.add_user(active_city, datagen.name(), datagen.address(), datagen.credit_card_number()))
+                    stats.add_latency_measurement("loading_screen", time.time() - start)
                 elif random.random() < .1:
                     # simulate a user adding a new vehicle to the population
+                    start = time.time()
                     movr_objects[active_city]["vehicles"].append(
                         movr.add_vehicle(active_city,
                                         owner_id = random.choice(movr_objects[active_city]["users"])['id'],
@@ -106,16 +120,21 @@ def simulate_movr_load(conn_string, cities, movr_objects, active_rides, read_per
                                         vehicle_metadata = MovRGenerator.generate_vehicle_metadata(type),
                                         status=MovRGenerator.get_vehicle_availability(),
                                         current_location = datagen.address()))
+                    stats.add_latency_measurement("add vehicle", time.time() - start)
                 elif random.random() < .5:
                     # simulate a user starting a ride
+                    start = time.time()
                     ride = movr.start_ride(active_city, random.choice(movr_objects[active_city]["users"])['id'],
                                            random.choice(movr_objects[active_city]["vehicles"])['id'])
                     active_rides.append(ride)
+                    stats.add_latency_measurement("start ride", time.time() - start)
                 else:
                     if len(active_rides):
                         #simulate a ride ending
+                        start = time.time()
                         ride = active_rides.pop()
                         movr.end_ride(ride['city'], ride['id'])
+                        stats.add_latency_measurement("end ride", time.time() - start)
 
 
 
@@ -375,10 +394,15 @@ def run_load_generator(conn_string, read_percentage, city_list, echo_sql, num_th
         RUNNING_THREADS.append(t)
 
     while True: #keep main thread alive to catch exit signals
-        time.sleep(0.5)
+        time.sleep(5)
+        stats.print_stats()
+        stats.new_window()
+
 
 if __name__ == '__main__':
 
+    global stats
+    stats = MovRStats()
     # support ctrl + c for exiting multithreaded operation
     signal.signal(signal.SIGINT, signal_handler)
 
@@ -426,6 +450,8 @@ if __name__ == '__main__':
                         args.skip_reload_tables, args.echo_sql, args.enable_geo_partitioning)
     else:
         run_load_generator(conn_string, args.read_percentage, args.city, args.echo_sql, args.num_threads)
+
+
 
 
 

--- a/loadmovr.py
+++ b/loadmovr.py
@@ -109,7 +109,7 @@ def simulate_movr_load(conn_string, cities, movr_objects, active_rides, read_per
                     # simulate new signup
                     start = time.time()
                     movr_objects[active_city]["users"].append(movr.add_user(active_city, datagen.name(), datagen.address(), datagen.credit_card_number()))
-                    stats.add_latency_measurement("loading_screen", time.time() - start)
+                    stats.add_latency_measurement("new user", time.time() - start)
                 elif random.random() < .1:
                     # simulate a user adding a new vehicle to the population
                     start = time.time()

--- a/movr_stats.py
+++ b/movr_stats.py
@@ -2,45 +2,47 @@ import numpy
 from tabulate import tabulate
 import time
 
-#@todo: is this threadsafe? turn this into a class
+
 class MovRStats:
 
     def __init__(self):
         self.window_stats = {}
-        self.total_measurements = 0
-        self.instantiation_time = time.time()
         self.window_start_time = time.time()
+        self.cumulative_counts = {}
+        self.instantiation_time = time.time()
 
+    # reset stats while keeping cumulative counts
     def new_window(self):
         self.window_start_time = time.time()
         self.window_stats = {}
 
-
-    def get_stats_row(self, command):
-        if command in self.window_stats:
-            elapsed = time.time() - self.instantiation_time
-            return [command, round(elapsed,0), len(self.window_stats[command]), len(self.window_stats[command])/elapsed,
-                    round(float(self.get_percentile_measurement(command, 50))*1000,2),
-                          round(float(self.get_percentile_measurement(command, 95))*1000,2),
-                          round(float(self.get_percentile_measurement(command, 99))*1000,2),
-                                round(float(self.get_percentile_measurement(command, 100))*1000,2)]
-        else:
-            return []
-
-
+    # add one latency measurement in seconds
     def add_latency_measurement(self, command, measurement):
         self.window_stats.setdefault(command,[]).append(measurement)
-        self.total_measurements+=1
+        self.cumulative_counts.setdefault(command,0)
+        self.cumulative_counts[command]+=1
 
-    def get_percentile_measurement(self,command, percentile):
-        return numpy.percentile(self.window_stats.setdefault(command,[0]),percentile)
-
+    # print the current stats this instance has collected
     def print_stats(self):
-        header = ["action", "elapsed secs", "num_operations", "ops/second", "p50(ms)", "p95(ms)", "p99(ms)", "max(ms)"]
+        def get_percentile_measurement(command, percentile):
+            return numpy.percentile(self.window_stats.setdefault(command, [0]), percentile)
+
+        def get_stats_row(command):
+            if command in self.window_stats:
+                elapsed = time.time() - self.instantiation_time
+                return [command, round(elapsed, 0), len(self.window_stats[command]), self.cumulative_counts[command],
+                        len(self.window_stats[command]) / elapsed,
+                        round(float(get_percentile_measurement(command, 50)) * 1000, 2),
+                        round(float(get_percentile_measurement(command, 95)) * 1000, 2),
+                        round(float(get_percentile_measurement(command, 99)) * 1000, 2),
+                        round(float(get_percentile_measurement(command, 100)) * 1000, 2)]
+            else:
+                return []
+
+        header = ["action", "time(total)", "ops(window)", "ops(total)", "ops/second", "p50(ms)", "p95(ms)", "p99(ms)", "max(ms)"]
         rows = []
 
         for command in sorted(list(self.window_stats)):
-            rows.append(self.get_stats_row(command))
+            rows.append(get_stats_row(command))
 
-        print(tabulate(rows, header))
-        print("")
+        print(tabulate(rows, header), "\n")

--- a/movr_stats.py
+++ b/movr_stats.py
@@ -56,7 +56,8 @@ class MovRStats:
         try:
             for command in sorted(list(self.window_stats)):
                 rows.append(get_stats_row(command))
+            print(tabulate(rows, header), "\n")
         finally:
             self.mutex.release()
 
-        print(tabulate(rows, header), "\n")
+

--- a/movr_stats.py
+++ b/movr_stats.py
@@ -1,0 +1,46 @@
+import numpy
+from tabulate import tabulate
+import time
+
+#@todo: is this threadsafe? turn this into a class
+class MovRStats:
+
+    def __init__(self):
+        self.window_stats = {}
+        self.total_measurements = 0
+        self.instantiation_time = time.time()
+        self.window_start_time = time.time()
+
+    def new_window(self):
+        self.window_start_time = time.time()
+        self.window_stats = {}
+
+
+    def get_stats_row(self, command):
+        if command in self.window_stats:
+            elapsed = time.time() - self.instantiation_time
+            return [command, round(elapsed,0), len(self.window_stats[command]), len(self.window_stats[command])/elapsed,
+                    round(float(self.get_percentile_measurement(command, 50))*1000,2),
+                          round(float(self.get_percentile_measurement(command, 95))*1000,2),
+                          round(float(self.get_percentile_measurement(command, 99))*1000,2),
+                                round(float(self.get_percentile_measurement(command, 100))*1000,2)]
+        else:
+            return []
+
+
+    def add_latency_measurement(self, command, measurement):
+        self.window_stats.setdefault(command,[]).append(measurement)
+        self.total_measurements+=1
+
+    def get_percentile_measurement(self,command, percentile):
+        return numpy.percentile(self.window_stats.setdefault(command,[0]),percentile)
+
+    def print_stats(self):
+        header = ["action", "elapsed secs", "num_operations", "ops/second", "p50(ms)", "p95(ms)", "p99(ms)", "max(ms)"]
+        rows = []
+
+        for command in sorted(list(self.window_stats)):
+            rows.append(self.get_stats_row(command))
+
+        print(tabulate(rows, header))
+        print("")

--- a/movr_stats.py
+++ b/movr_stats.py
@@ -30,7 +30,7 @@ class MovRStats:
         def get_stats_row(command):
             if command in self.window_stats:
                 elapsed = time.time() - self.instantiation_time
-                return [command, round(elapsed, 0), len(self.window_stats[command]), self.cumulative_counts[command],
+                return [command, round(elapsed, 0),  self.cumulative_counts[command], len(self.window_stats[command]),
                         len(self.window_stats[command]) / elapsed,
                         round(float(get_percentile_measurement(command, 50)) * 1000, 2),
                         round(float(get_percentile_measurement(command, 95)) * 1000, 2),
@@ -39,7 +39,7 @@ class MovRStats:
             else:
                 return []
 
-        header = ["action", "time(total)", "ops(window)", "ops(total)", "ops/second", "p50(ms)", "p95(ms)", "p99(ms)", "max(ms)"]
+        header = ["action", "time(total)",  "ops(total)", "ops", "ops/second", "p50(ms)", "p95(ms)", "p99(ms)", "max(ms)"]
         rows = []
 
         for command in sorted(list(self.window_stats)):

--- a/movr_stats.py
+++ b/movr_stats.py
@@ -8,11 +8,10 @@ class MovRStats:
 
 
     def __init__(self):
-        self.window_stats = {}
-        self.window_start_time = time.time()
         self.cumulative_counts = {}
         self.instantiation_time = time.time()
         self.mutex = Lock()
+        self.new_window()
 
     # reset stats while keeping cumulative counts
     def new_window(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ faker
 sqlalchemy-utils
 psycopg2-binary
 tabulate
+numpy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ names
 faker
 sqlalchemy-utils
 psycopg2-binary
+tabulate
 


### PR DESCRIPTION
Updated MovR to capture a variety of client-side transaction statistics. Example:

![image](https://user-images.githubusercontent.com/894257/56063273-d84f3000-5d3c-11e9-9779-3cd6829af242.png)


Fixes #76 