### PR TITLE
remove hard coded port number in regex

### DIFF
--- a/loadmovr.py
+++ b/loadmovr.py
@@ -499,7 +499,7 @@ if __name__ == '__main__':
 
     args = setup_parser().parse_args()
 
-    if not re.search('.*26257/(.*)\?', args.conn_string):
+    if not re.search('.*://.*/(.*)\?', args.conn_string):
         logging.error("The connection string needs to point to a database. Example: postgres://root@localhost:26257/mymovrdatabase?sslmode=disable")
         sys.exit(1)
 


### PR DESCRIPTION
Fixes #87 

```
Nathaniels-MacBook-Pro:movr nate$ docker run -it --rm cockroachdb/movr:19.06.1 --url 'postgres://root@docker.for.mac.localhost:58023/movr?sslmode=disable' run
[INFO] (MainThread) connected to movr database @ postgres://root@docker.for.mac.localhost:58023/movr?sslmode=disable
[INFO] (MainThread) simulating movr load for cities ['new york', 'boston', 'washington dc', 'san francisco', 'seattle', 'los angeles', 'chicago', 'detroit', 'minneapolis', 'amsterdam', 'paris', 'rome']
[INFO] (MainThread) warming up....
transaction name      time(total)    ops(total)    ops    ops/second    p50(ms)    p90(ms)    p95(ms)    max(ms)
------------------  -------------  ------------  -----  ------------  ---------  ---------  ---------  ---------
add vehicle                    16            10     10      0.645081      17.38      19.93      20.13      20.34
apply promo code               16            12     12      0.773947      29.4       35.39      37.39      39.56
end ride                       16            41     41      2.64413       34.35      51.58      53.91      58.4
get vehicles                   16          2909   2909    187.595         19.47      28.55      31.87      67.58
log ride location              16           544    544     35.0781        17.41      26.28      29.18      52.84
new promo code                 16             3      3      0.193413      16.89      19.62      19.96      20.3
new user                       16            44     44      2.8364        19.71      28.31      30.87      34.89
start ride                     16            38     38      2.44942       34.72      51.36      52.33      53.02 
```