### PR TITLE
Add follower reads support

### DIFF
--- a/loadmovr.py
+++ b/loadmovr.py
@@ -295,7 +295,7 @@ def setup_parser():
                             help='The number of seconds to keep database connections alive before resetting them.',
                             default=30)
     run_parser.add_argument('--follower-reads', dest='follower_reads', action='store_true', default=False,
-                             help='Use the closest replica to serve the slightly stale read requests')
+                             help='Use the closest replica to serve fast, but slightly stale read requests')
     run_parser.add_argument('--city', dest='city', action='append',
                             help='The names of the cities to use when generating load. Use this flag multiple times to add multiple cities.')
     run_parser.add_argument('--read-only-percentage', dest='read_percentage', type=float,

--- a/loadmovr.py
+++ b/loadmovr.py
@@ -295,7 +295,7 @@ def setup_parser():
                             help='The number of seconds to keep database connections alive before resetting them.',
                             default=30)
     run_parser.add_argument('--follower-reads', dest='follower_reads', action='store_true', default=False,
-                             help='Use the closest replica to serve fast, but slightly stale read requests')
+                             help='Use the closest replica to serve fast, but slightly stale, read requests')
     run_parser.add_argument('--city', dest='city', action='append',
                             help='The names of the cities to use when generating load. Use this flag multiple times to add multiple cities.')
     run_parser.add_argument('--read-only-percentage', dest='read_percentage', type=float,

--- a/loadmovr.py
+++ b/loadmovr.py
@@ -101,6 +101,7 @@ def simulate_movr_load(conn_string, cities, movr_objects, active_rides, read_per
             if random.random() < read_percentage:
                 # simulate user loading screen
                 start = time.time()
+                #@todo: candidate for follower read
                 movr.get_vehicles(active_city,25)
                 stats.add_latency_measurement("get vehicles",time.time() - start )
 

--- a/movr.py
+++ b/movr.py
@@ -102,42 +102,42 @@ class MovR:
                                                                   city, owner_id, current_location, type,
                                                                   vehicle_metadata, status))
 
-    def get_users(self, city, follower_read=False, limit=None):
-        def get_users_helper(session, city, follower_read, limit=None):
-            if follower_read:
+    def get_users(self, city, follower_reads=False, limit=None):
+        def get_users_helper(session, city, follower_reads, limit=None):
+            if follower_reads:
                 session.execute(text('SET TRANSACTION AS OF SYSTEM TIME experimental_follower_read_timestamp()'))
             users = session.query(User).filter_by(city=city).limit(limit).all()
             return list(map(lambda user: {'city': user.city, 'id': user.id}, users))
-        return run_transaction(sessionmaker(bind=self.engine), lambda session: get_users_helper(session, city, follower_read, limit))
+        return run_transaction(sessionmaker(bind=self.engine), lambda session: get_users_helper(session, city, follower_reads, limit))
 
-    def get_vehicles(self, city, follower_read=False, limit=None):
+    def get_vehicles(self, city, follower_reads=False, limit=None):
 
-            def get_vehicles_helper(session, city, follower_read, limit=None):
-                if follower_read:
+            def get_vehicles_helper(session, city, follower_reads, limit=None):
+                if follower_reads:
                     session.execute(text('SET TRANSACTION AS OF SYSTEM TIME experimental_follower_read_timestamp()'))
                 vehicles = session.query(Vehicle).filter_by(city=city).limit(limit).all()
                 return list(map(lambda vehicle: {'city': vehicle.city, 'id': vehicle.id}, vehicles))
 
-            return run_transaction(sessionmaker(bind=self.engine), lambda session: get_vehicles_helper(session, city, follower_read, limit))
+            return run_transaction(sessionmaker(bind=self.engine), lambda session: get_vehicles_helper(session, city, follower_reads, limit))
 
-    def get_active_rides(self, city, follower_read=False, limit=None):
-        def get_active_rides_helper(session, city, follower_read, limit=None):
-            if follower_read:
+    def get_active_rides(self, city, follower_reads=False, limit=None):
+        def get_active_rides_helper(session, city, follower_reads, limit=None):
+            if follower_reads:
                 session.execute(text('SET TRANSACTION AS OF SYSTEM TIME experimental_follower_read_timestamp()'))
             rides = session.query(Ride).filter_by(city=city, end_time=None).limit(limit).all()
             return list(map(lambda ride: {'city': city, 'id': ride.id}, rides))
 
         return run_transaction(sessionmaker(bind=self.engine),
-                               lambda session: get_active_rides_helper(session, city, follower_read, limit))
+                               lambda session: get_active_rides_helper(session, city, follower_reads, limit))
 
-    def get_promo_codes(self, follower_read=False, limit=None):
-        def get_promo_codes_helper(session, follower_read, limit=None):
-            if follower_read:
+    def get_promo_codes(self, follower_reads=False, limit=None):
+        def get_promo_codes_helper(session, follower_reads, limit=None):
+            if follower_reads:
                 session.execute(text('SET TRANSACTION AS OF SYSTEM TIME experimental_follower_read_timestamp()'))
             pcs = session.query(PromoCode).limit(limit).all()
             return list(map(lambda pc: pc.code, pcs))
 
-        return run_transaction(sessionmaker(bind=self.engine), lambda session: get_promo_codes_helper(session, follower_read, limit))
+        return run_transaction(sessionmaker(bind=self.engine), lambda session: get_promo_codes_helper(session, follower_reads, limit))
 
 
     def create_promo_code(self, code, description, expiration_time, rules):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-sqlalchemy
-cockroachdb
+SQLAlchemy==1.2.10
+cockroachdb>=0.3.2
 names
 faker
 sqlalchemy-utils


### PR DESCRIPTION
This adds the `--follower-reads` command to movr, which allows you to demo historical reads on read-only transactions. This reduces the latency on the frequent `get_vehicles` transaction, which models a user opening the app. 

This unblocks #56 