### PR TITLE
Support single region deployments [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MovR
 
-MovR is a fictional ride sharing company. This repo contains links to datasets and a load generator.
+MovR is a fictional ride sharing company.
 
 
 ## Getting started
@@ -12,8 +12,18 @@ Generating fake data: `docker run -it --rm cockroachdb/movr --url "postgres://ro
 
 Generating load for cities: `docker run -it --rm cockroachdb/movr --url "postgres://root@docker.for.mac.localhost:26257/movr?sslmode=disable" --num-threads 10 run --city "new york" --city "boston"`
 
+## Multi-region configuration
+MovR defaults to a single-region schema and single-region queries. You can also run MovR in a multi-region configuration.
+
+Generating multi-region data: `docker run -it --rm cockroachdb/movr --url "postgres://root@docker.for.mac.localhost:26257/movr?sslmode=disable" load --multi-region`
+Running multi-region queries: `docker run -it --rm cockroachdb/movr --url "postgres://root@docker.for.mac.localhost:26257/movr?sslmode=disable" run --multi-region`
+
+You can also convert a existing single-region MovR database to a multi-region one without downtime.
+
+Convert to multi-region schema: `docker run -it --rm cockroachdb/movr --url "postgres://root@docker.for.mac.localhost:26257/movr?sslmode=disable" configure-multi-region`
+
 ## Partitioning MovR
-MovR can automatically partition data and apply zone configs using the `partition` command.
+MovR can automatically partition multi-region data and apply zone configs using the `partition` command.
 Use region-city pairs to map cities to regional partitions and use region-zone pairs to map regional partitions to zones
 `docker run -it --rm cockroachdb/movr --echo-sql --app-name "movr-partition" --url "postgres://root@[ipaddress]/movr?sslmode=disable" partition --region-city-pair us_east:"new york" --region-city-pair central:chicago --region-city-pair us_west:seattle  --region-zone-pair us_east:us-east1 --region-zone-pair central:us-central1 --region-zone-pair us_west:us-west1`
 
@@ -46,99 +56,4 @@ ALTER TABLE users PARTITION BY LIST (city) (PARTITION new_york VALUES IN ('new y
 ALTER TABLE rides PARTITION BY LIST (city) (PARTITION new_york VALUES IN ('new york' ), PARTITION chicago VALUES IN ('chicago' ), PARTITION seattle VALUES IN ('seattle' ));
 ```
 
-## Pre-built datasets
 
-### MovR 1M
-This dataset contains 1M users, 1M rides, and 10k vehicles.
-
-
-Import Users
-```
-IMPORT TABLE users (
-        id UUID NOT NULL,
-        city VARCHAR NOT NULL,
-        name VARCHAR NULL,
-        address VARCHAR NULL,
-        credit_card VARCHAR NULL,
-        CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
-        FAMILY "primary" (id, city, name, address, credit_card)
-)
-CSV DATA (
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/users/n1.0.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/users/n1.1.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/users/n1.2.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/users/n1.3.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/users/n1.4.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/users/n1.5.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/users/n1.6.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/users/n1.7.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/users/n1.8.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/users/n1.9.csv',
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/users/n1.10.csv');
-
-```
-Import vehicles
-```
-IMPORT TABLE vehicles (
-        id UUID NOT NULL,
-        city VARCHAR NOT NULL,
-        type VARCHAR NULL,
-        owner_id UUID NULL,
-        creation_time TIMESTAMP NULL,
-        status VARCHAR NULL,
-        current_location VARCHAR NULL,
-        ext JSONB NULL,
-        CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
-        INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC),
-        INVERTED INDEX ix_vehicle_ext (ext),
-        FAMILY "primary" (id, city, type, owner_id, creation_time, status, current_location, ext)
-)                                                                                                                                                                
-CSV DATA ('https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/vehicles/n1.0.csv');
-
-```
-
-Import rides
-```
-IMPORT TABLE rides (
-        id UUID NOT NULL,
-        city VARCHAR NOT NULL,
-        vehicle_city VARCHAR NULL,
-        rider_id UUID NULL,
-        vehicle_id UUID NULL,
-        start_address VARCHAR NULL,
-        end_address VARCHAR NULL,
-        start_time TIMESTAMP NULL,
-        end_time TIMESTAMP NULL,
-        revenue DECIMAL(10,2) NULL,
-        CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
-        INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC),
-        INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC),
-        FAMILY "primary" (id, city, vehicle_city, rider_id, vehicle_id, start_address, end_address, start_time, end_time, revenue),
-        CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city)
-) 
-CSV DATA (
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/rides/n1.0.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/rides/n1.1.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/rides/n1.2.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/rides/n1.3.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/rides/n1.4.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/rides/n1.5.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/rides/n1.6.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/rides/n1.7.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/rides/n1.8.csv', 
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/rides/n1.9.csv',
-'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/movr-1m/rides/n1.10.csv');
-```
-
-Setup and validate integrity constraints
-```
-ALTER TABLE vehicles ADD CONSTRAINT fk_city_ref_users FOREIGN KEY (city, owner_id) REFERENCES users (city, id);
-ALTER TABLE rides ADD CONSTRAINT fk_city_ref_users FOREIGN KEY (city, rider_id) REFERENCES users (city, id);
-ALTER TABLE rides ADD CONSTRAINT fk_vehicle_city_ref_vehicles FOREIGN KEY (vehicle_city, vehicle_id) REFERENCES vehicles (city, id);
-
-ALTER TABLE vehicles VALIDATE CONSTRAINT fk_city_ref_users;
-ALTER TABLE rides VALIDATE CONSTRAINT fk_city_ref_users;
-ALTER TABLE rides VALIDATE CONSTRAINT fk_vehicle_city_ref_vehicles;
-
-
-```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 MovR is a fictional ride sharing company.
 
-
 ## Getting started
 First, [download CockroachDB](https://www.cockroachlabs.com/docs/stable/install-cockroachdb.html) and start a local cluster with `cockroach start --insecure --host localhost --background`
 
@@ -13,7 +12,7 @@ Generating fake data: `docker run -it --rm cockroachdb/movr --url "postgres://ro
 Generating load for cities: `docker run -it --rm cockroachdb/movr --url "postgres://root@docker.for.mac.localhost:26257/movr?sslmode=disable" --num-threads 10 run --city "new york" --city "boston"`
 
 ## Multi-region configuration
-MovR defaults to a single-region schema and single-region queries. You can also run MovR in a multi-region configuration.
+MovR defaults to a single-region schema and single-region queries. You can also run MovR in a multi-region configuration. *This requires CockroachDB 20.1-beta.4 or later.*
 
 Generating multi-region data: `docker run -it --rm cockroachdb/movr --url "postgres://root@docker.for.mac.localhost:26257/movr?sslmode=disable" load --multi-region`
 Running multi-region queries: `docker run -it --rm cockroachdb/movr --url "postgres://root@docker.for.mac.localhost:26257/movr?sslmode=disable" run --multi-region`

--- a/loadmovr.py
+++ b/loadmovr.py
@@ -265,7 +265,7 @@ def setup_parser():
     ###############
     load_parser = subparsers.add_parser('load', help="load movr data into a database")
     load_parser.add_argument('--multi-region', dest='multi_region', action='store_true', default=False,
-                        help='Load MovR with multi region schemas. Useful for showing an app build from day-one for a global deployment. You can convert a single region MovR to multi-region one using the "configure-multi-region" command')
+                        help='Load MovR with multi-region schemas. Useful for showing an app built from day-one for a global deployment. You can convert a single-region MovR to multi-region one using the "configure-multi-region" command')
     load_parser.add_argument('--num-users', dest='num_users', type=int, default=50,
                              help='The number of random users to add to the dataset')
     load_parser.add_argument('--num-vehicles', dest='num_vehicles', type=int, default=10,
@@ -286,7 +286,7 @@ def setup_parser():
     ###############
     run_parser = subparsers.add_parser('run', help="generate fake traffic for the movr database")
     run_parser.add_argument('--multi-region', dest='multi_region', action='store_true', default=False,
-                            help='Run MovR with single region queries that use composite primary keys. Requires multi-region schema options.')
+                            help='Run MovR with single-region queries that use composite primary keys. Requires multi-region schema options.')
     run_parser.add_argument('--connection-duration', dest='connection_duration_in_seconds', type=int,
                             help='The number of seconds to keep database connections alive before resetting them.',
                             default=30)

--- a/loadmovr.py
+++ b/loadmovr.py
@@ -428,7 +428,7 @@ def run_data_loader(conn_string, cities, num_users, num_rides, num_vehicles, num
 
     logging.info("Loading single region MovR") if use_single_region else logging.info("Loading multi region MovR")
 
-    with MovR(conn_string, init_tables=(not skip_reload_tables), single_region = use_single_region, echo=echo_sql) as movr:
+    with MovR(conn_string, init_tables=(not skip_reload_tables), multi_region = not use_single_region, echo=echo_sql) as movr:
 
         logging.info("loading cities %s", cities)
         logging.info("loading movr data with ~%d users, ~%d vehicles, ~%d rides, ~%d histories, and ~%d promo codes",
@@ -548,9 +548,10 @@ if __name__ == '__main__':
 
 
     if args.subparser_name=='load':
-        run_data_loader(conn_string, get_cities(args.city), args.num_users, args.num_rides, args.num_vehicles, args.num_histories,
-                        args.num_promo_codes, args.num_threads, args.single_region,
-                        args.skip_reload_tables, args.echo_sql)
+
+        run_data_loader(conn_string, cities= get_cities(args.city), num_users= args.num_users, num_rides= args.num_rides, num_vehicles= args.num_vehicles, num_histories= args.num_histories,
+                        num_promo_codes= args.num_promo_codes, num_threads= args.num_threads, use_single_region=args.single_region,
+                        skip_reload_tables= args.skip_reload_tables, echo_sql= args.echo_sql)
     elif args.subparser_name=="partition":
         # population partitions
         partition_city_map = extract_region_city_pairs_from_cli(args.region_city_pair)

--- a/loadmovr.py
+++ b/loadmovr.py
@@ -251,7 +251,8 @@ def setup_parser():
                         help='The name that can be used for filtering statements by client in the Admin UI.')
     parser.add_argument('--url', dest='conn_string', default='postgres://root@localhost:26257/movr?sslmode=disable',
                         help="connection string to movr database. Default is 'postgres://root@localhost:26257/movr?sslmode=disable'")
-
+    parser.add_argument('--single-region', dest='single_region', action='store_true', default=False,
+                             help='Run MovR with single region schemas. Useful for showing an app that starts small and scales out.')
     parser.add_argument('--echo-sql', dest='echo_sql', action='store_true',
                         help='set this if you want to print all executed SQL statements')
 

--- a/loadmovr.py
+++ b/loadmovr.py
@@ -418,16 +418,17 @@ def add_vehicles(engine, num_vehicles, city):
         run_transaction(sessionmaker(bind=engine),
                         lambda s: add_vehicles_helper(s, chunk, min(chunk + chunk_size, num_vehicles)))
 
+#@todo: switch to named arguments
 def run_data_loader(conn_string, cities, num_users, num_rides, num_vehicles, num_histories, num_promo_codes, num_threads,
-                    skip_reload_tables, echo_sql):
+                    skip_reload_tables, use_single_region, echo_sql):
     if num_users <= 0 or num_rides <= 0 or num_vehicles <= 0:
         raise ValueError("The number of objects to generate must be > 0")
 
     start_time = time.time()
 
+    logging.info("Loading single region MovR") if use_single_region else logging.info("Loading multi region MovR")
 
-
-    with MovR(conn_string, init_tables=(not skip_reload_tables), echo=echo_sql) as movr:
+    with MovR(conn_string, init_tables=(not skip_reload_tables), single_region = use_single_region, echo=echo_sql) as movr:
 
         logging.info("loading cities %s", cities)
         logging.info("loading movr data with ~%d users, ~%d vehicles, ~%d rides, ~%d histories, and ~%d promo codes",
@@ -547,7 +548,8 @@ if __name__ == '__main__':
 
 
     if args.subparser_name=='load':
-        run_data_loader(conn_string, get_cities(args.city), args.num_users, args.num_rides, args.num_vehicles, args.num_histories, args.num_promo_codes, args.num_threads,
+        run_data_loader(conn_string, get_cities(args.city), args.num_users, args.num_rides, args.num_vehicles, args.num_histories,
+                        args.num_promo_codes, args.num_threads, args.single_region,
                         args.skip_reload_tables, args.echo_sql)
     elif args.subparser_name=="partition":
         # population partitions

--- a/loadmovr.py
+++ b/loadmovr.py
@@ -342,7 +342,6 @@ def add_rides(engine, num_rides, city):
             start_time = datetime.datetime.now() - datetime.timedelta(days=random.randint(0, 30))
             rides.append(Ride(id=MovRGenerator.generate_uuid(),
                               city=city,
-                              vehicle_city=city,
                               rider_id=random.choice(users).id,
                               vehicle_id=random.choice(vehicles).id,
                               start_time=start_time,

--- a/models.py
+++ b/models.py
@@ -20,11 +20,10 @@ Base = declarative_base()
 class User(Base):
     __tablename__ = 'users'
     id = Column(UUID, primary_key=True, default=MovRGenerator.generate_uuid)
-    city = Column(String)
+    city = Column(String, nullable=False)
     name = Column(String)
     address = Column(String)
     credit_card = Column(String)
-    #PrimaryKeyConstraint(city, id)
     #promo_codes = relationship("UserPromoCode")
 
     def __repr__(self):
@@ -34,7 +33,8 @@ class User(Base):
 class Ride(Base):
     __tablename__ = 'rides'
     id = Column(UUID, primary_key=True, default=MovRGenerator.generate_uuid)
-    city = Column(String)
+    city = Column(String, nullable=False)
+    #@todo: we don't need this for single region
     vehicle_city = Column(String, CheckConstraint('vehicle_city=city')) #@todo: annoying workaround for https://github.com/cockroachdb/cockroach/issues/23580
     rider_id = Column(UUID)
     vehicle_id = Column(UUID)
@@ -43,12 +43,8 @@ class Ride(Base):
     start_time = Column(DateTime, default=datetime.datetime.now)
     end_time = Column(DateTime)
     revenue = Column(DECIMAL(10,2))
-    #PrimaryKeyConstraint(city, id)
-    #@todo: fix fks to make them signle region
-    #__table_args__ = (ForeignKeyConstraint([city, rider_id], ["users.city", "users.id"]),) #this requires an index or it fails silently:  https://github.com/cockroachdb/cockroach/issues/22253
-    #__table_args__ = (ForeignKeyConstraint([vehicle_city, vehicle_id], ["vehicles.city", "vehicles.id"]),)
-    __table_args__ = (ForeignKeyConstraint([rider_id], ["users.id"]),)  # this requires an index or it fails silently:  https://github.com/cockroachdb/cockroach/issues/22253
-    __table_args__ = (ForeignKeyConstraint([vehicle_id], ["vehicles.id"]),)
+    __table_args__ = (ForeignKeyConstraint([rider_id], ["users.id"], name='fk_rider_id_ref_users'),)  # this requires an index or it fails silently:  https://github.com/cockroachdb/cockroach/issues/22253
+    __table_args__ = (ForeignKeyConstraint([vehicle_id], ["vehicles.id"], name='fk_vehicle_id_ref_vehicles'),)
 
 
     def __repr__(self):
@@ -56,12 +52,11 @@ class Ride(Base):
 
 class VehicleLocationHistory(Base):
     __tablename__ = 'vehicle_location_histories'
-    city = Column(String)
+    city = Column(String, nullable=False)
     ride_id = Column(UUID)
     timestamp = Column(DateTime, default=datetime.datetime.now)
     lat = Column(Float)
     long = Column(Float)
-    #PrimaryKeyConstraint(city, ride_id, timestamp)
     PrimaryKeyConstraint(ride_id, timestamp)
     #__table_args__ = (ForeignKeyConstraint([city, ride_id], ["rides.city", "rides.id"]),) #@todo: cut until FK performance improves in 19.2
 
@@ -72,16 +67,14 @@ class VehicleLocationHistory(Base):
 class Vehicle(Base):
     __tablename__ = 'vehicles'
     id = Column(UUID, primary_key=True, default=MovRGenerator.generate_uuid)
-    city = Column(String)
+    city = Column(String, nullable=False)
     type = Column(String)
     owner_id = Column(UUID)
     creation_time = Column(DateTime, default=datetime.datetime.now)
     status = Column(String)
     current_location = Column(String)
     ext = Column(JSONB)
-    #PrimaryKeyConstraint(city, id)
-    #__table_args__ = (ForeignKeyConstraint([city, owner_id], ["users.city", "users.id"]),)
-    __table_args__ = (ForeignKeyConstraint([owner_id], ["users.id"]),)
+    __table_args__ = (ForeignKeyConstraint([owner_id], ["users.id"], name='fk_owner_id_ref_users'),)
 
     def __repr__(self):
         return "<Vehicle(city='%s', id='%s', type='%s', status='%s', ext='%s')>" % (self.city, self.id, self.type, self.status, self.ext)
@@ -94,7 +87,6 @@ class PromoCode(Base):
     expiration_time = Column(DateTime)
     rules = Column(JSONB)
 
-    #PrimaryKeyConstraint(code)
     def __repr__(self):
         return "<PromoCode(code='%s', description='%s', creation_time='%s', expiration_time='%s', rules='%s')>" % \
                (self.code, self.description, self.creation_time, self.expiration_time, self.rules)
@@ -102,20 +94,19 @@ class PromoCode(Base):
 
 class UserPromoCode(Base):
     __tablename__ = 'user_promo_codes'
-    city = Column(String)
+    city = Column(String, nullable=False)
     user_id = Column(UUID)
     code = Column(String)
     timestamp = Column(DateTime, default=datetime.datetime.now)
     usage_count = Column(Integer, default=0)
     #promo_code = relationship("PromoCode")
 
-    #PrimaryKeyConstraint(city, user_id, code)
     PrimaryKeyConstraint(user_id, code)
 
     #__table_args__ = (ForeignKeyConstraint([city, user_id], ["users.city",
      #                                                         "users.id"]),)
     #__table_args__ = (ForeignKeyConstraint([code], ["promo_codes.code"]),)
-    __table_args__ = (ForeignKeyConstraint([user_id], ["users.id"]),)
+    __table_args__ = (ForeignKeyConstraint([user_id], ["users.id"], name='fk_user_id_ref_users'),)
 
     def __repr__(self):
         return "<UserPromoCode(city='%s', user_id='%s', code='%s', timestamp='%s')>" % \

--- a/models.py
+++ b/models.py
@@ -74,6 +74,8 @@ class Vehicle(Base):
     ext = Column(JSONB)
     __table_args__ = (ForeignKeyConstraint([owner_id], ["users.id"], name='fk_owner_id_ref_users'),)
 
+    Index('vehicles_city_idx', city)
+
     def __repr__(self):
         return "<Vehicle(city='%s', id='%s', type='%s', status='%s', ext='%s')>" % (self.city, self.id, self.type, self.status, self.ext)
 

--- a/models.py
+++ b/models.py
@@ -34,8 +34,11 @@ class Ride(Base):
     __tablename__ = 'rides'
     id = Column(UUID, primary_key=True, default=MovRGenerator.generate_uuid)
     city = Column(String, nullable=False)
-    #@todo: we don't need this for single region
-    vehicle_city = Column(String, CheckConstraint('vehicle_city=city')) #@todo: annoying workaround for https://github.com/cockroachdb/cockroach/issues/23580
+
+    # @todo: annoying workaround for https://github.com/cockroachdb/cockroach/issues/23580
+    # @todo: ideally we would not include this in the single region configuration,
+    # but adding this after the fact is tricky because we can't use computed columns or sub-expresssions as default
+    vehicle_city = Column(String, CheckConstraint('vehicle_city=city'))
     rider_id = Column(UUID)
     vehicle_id = Column(UUID)
     start_address = Column(String)

--- a/models.py
+++ b/models.py
@@ -34,11 +34,6 @@ class Ride(Base):
     __tablename__ = 'rides'
     id = Column(UUID, primary_key=True, default=MovRGenerator.generate_uuid)
     city = Column(String, nullable=False)
-
-    # @todo: annoying workaround for https://github.com/cockroachdb/cockroach/issues/23580
-    # @todo: ideally we would not include this in the single region configuration,
-    # but adding this after the fact is tricky because we can't use computed columns or sub-expresssions as default
-    vehicle_city = Column(String, CheckConstraint('vehicle_city=city'))
     rider_id = Column(UUID)
     vehicle_id = Column(UUID)
     start_address = Column(String)

--- a/models.py
+++ b/models.py
@@ -26,6 +26,8 @@ class User(Base):
     credit_card = Column(String)
     #promo_codes = relationship("UserPromoCode")
 
+    Index('users_city_idx', city)
+
     def __repr__(self):
         return "<User(city='%s', id='%s', name='%s')>" % (self.city, self.id, self.name)
 

--- a/movr.py
+++ b/movr.py
@@ -55,7 +55,7 @@ class MovR:
                         UserPromoCode).filter_by(user_id=rider_id,code=upc.code)
                     code_to_update.update({'usage_count': upc.usage_count+1})
 
-            r = Ride(city=city, vehicle_city=city, id=MovRGenerator.generate_uuid(),
+            r = Ride(city=city, id=MovRGenerator.generate_uuid(),
                      rider_id=rider_id, vehicle_id=vehicle_id,
                      start_address=v.current_location)
 
@@ -206,9 +206,9 @@ class MovR:
         queries_to_run["fk_alters"].append(
             "ALTER TABLE rides ADD CONSTRAINT fk_rider_id_ref_users_mr FOREIGN KEY (city, rider_id) REFERENCES users (city,id);")
         queries_to_run["fk_alters"].append("ALTER TABLE rides DROP CONSTRAINT fk_vehicle_id_ref_vehicles;")
-        queries_to_run["fk_alters"].append("CREATE INDEX ON rides (vehicle_city, vehicle_id);")
+        queries_to_run["fk_alters"].append("CREATE INDEX ON rides (city, vehicle_id);")
         queries_to_run["fk_alters"].append(
-            "ALTER TABLE rides ADD CONSTRAINT fk_vehicle_id_ref_vehicles_mr FOREIGN KEY (vehicle_city, vehicle_id) REFERENCES vehicles (city,id);")
+            "ALTER TABLE rides ADD CONSTRAINT fk_vehicle_id_ref_vehicles_mr FOREIGN KEY (city, vehicle_id) REFERENCES vehicles (city,id);")
         queries_to_run["fk_alters"].append("DROP INDEX rides_auto_index_fk_rider_id_ref_users;")
         queries_to_run["fk_alters"].append("DROP INDEX rides_auto_index_fk_vehicle_id_ref_vehicles;")
 
@@ -279,7 +279,7 @@ class MovR:
                 queries_to_run.setdefault("table_zones",[]).append(zone_sql)
 
         for index in [{"index_name": "rides_city_rider_id_idx", "prefix_name": "city", "table": "rides"},
-                      {"index_name": "rides_vehicle_city_vehicle_id_idx", "prefix_name": "vehicle_city",
+                      {"index_name": "rides_city_vehicle_id_idx", "prefix_name": "city",
                        "table": "rides"},
                       {"index_name": "vehicles_city_owner_id_idx", "prefix_name": "city",
                        "table": "vehicles"}]:

--- a/movr.py
+++ b/movr.py
@@ -15,7 +15,7 @@ class MovR:
     def __exit__(self, exc_type, exc_value, traceback):
         self.session.close()
 
-    def __init__(self, conn_string, init_tables = False, single_region = False, echo = False):
+    def __init__(self, conn_string, init_tables = False, multi_region = False, echo = False):
 
 
         self.engine = create_engine(conn_string, convert_unicode=True, echo=echo)
@@ -25,7 +25,7 @@ class MovR:
             logging.info("initializing tables")
             Base.metadata.drop_all(bind=self.engine)
             Base.metadata.create_all(bind=self.engine)
-            if not single_region:
+            if multi_region:
                 self.run_multi_region_transformations()
 
 
@@ -177,7 +177,7 @@ class MovR:
     ################
 
     def run_multi_region_transformations(self):
-        logging.info("applying schema changes to make this database multi-region")
+        logging.info("applying schema changes to make this database multi-region (this may take a minute)")
         queries_to_run = []
         queries_to_run.append("ALTER TABLE users ALTER PRIMARY KEY USING COLUMNS (city, id)")
         queries_to_run.append("ALTER TABLE rides ALTER PRIMARY KEY USING COLUMNS (city, id)")

--- a/movr.py
+++ b/movr.py
@@ -220,7 +220,6 @@ class MovR:
         queries_to_run["fk_alters"].append("DROP INDEX rides_auto_index_fk_rider_id_ref_users;")
         queries_to_run["fk_alters"].append("DROP INDEX rides_auto_index_fk_vehicle_id_ref_vehicles;")
 
-        # @todo: remove single region index
         # user_promo_codes
         queries_to_run["fk_alters"].append("ALTER TABLE user_promo_codes DROP CONSTRAINT fk_user_id_ref_users;")
         queries_to_run["fk_alters"].append(

--- a/movr.py
+++ b/movr.py
@@ -219,7 +219,7 @@ class MovR:
         return queries_to_run
 
     def run_multi_region_transformations(self):
-        logging.info("applying schema changes to make this database multi-region (this may take a minute or two).")
+        logging.info("applying schema changes to make this database multi-region (this may take up to a minute).")
         queries_to_run = self.get_multi_region_transformations()
 
 

--- a/movr.py
+++ b/movr.py
@@ -196,6 +196,7 @@ class MovR:
         queries_to_run["fk_alters"].append("ALTER TABLE vehicles DROP CONSTRAINT fk_owner_id_ref_users;")
         #foreign key requires an existing index on columns
         queries_to_run["fk_alters"].append("CREATE INDEX ON vehicles (city, owner_id);")
+        queries_to_run["fk_alters"].append("DROP INDEX vehicles_auto_index_fk_owner_id_ref_users;")
         queries_to_run["fk_alters"].append(
             "ALTER TABLE vehicles ADD CONSTRAINT fk_owner_id_ref_users_mr FOREIGN KEY (city, owner_id) REFERENCES users (city,id);")
 
@@ -208,9 +209,10 @@ class MovR:
         queries_to_run["fk_alters"].append("CREATE INDEX ON rides (vehicle_city, vehicle_id);")
         queries_to_run["fk_alters"].append(
             "ALTER TABLE rides ADD CONSTRAINT fk_vehicle_id_ref_vehicles_mr FOREIGN KEY (vehicle_city, vehicle_id) REFERENCES vehicles (city,id);")
+        queries_to_run["fk_alters"].append("DROP INDEX rides_auto_index_fk_rider_id_ref_users;")
+        queries_to_run["fk_alters"].append("DROP INDEX rides_auto_index_fk_vehicle_id_ref_vehicles;")
 
-
-
+        # @todo: remove single region index
         # user_promo_codes
         queries_to_run["fk_alters"].append("ALTER TABLE user_promo_codes DROP CONSTRAINT fk_user_id_ref_users;")
         queries_to_run["fk_alters"].append(
@@ -276,10 +278,10 @@ class MovR:
                            zone_map[partition_name] + "]';"
                 queries_to_run.setdefault("table_zones",[]).append(zone_sql)
 
-        for index in [{"index_name": "rides_auto_index_fk_city_ref_users", "prefix_name": "city", "table": "rides"},
-                      {"index_name": "rides_auto_index_fk_vehicle_city_ref_vehicles", "prefix_name": "vehicle_city",
+        for index in [{"index_name": "rides_city_rider_id_idx", "prefix_name": "city", "table": "rides"},
+                      {"index_name": "rides_vehicle_city_vehicle_id_idx", "prefix_name": "vehicle_city",
                        "table": "rides"},
-                      {"index_name": "vehicles_auto_index_fk_city_ref_users", "prefix_name": "city",
+                      {"index_name": "vehicles_city_owner_id_idx", "prefix_name": "city",
                        "table": "vehicles"}]:
             partition_string = create_partition_string(index_name=index["index_name"])
             partition_sql = "ALTER INDEX " + index["index_name"] + " PARTITION BY LIST (" + index[

--- a/movr.py
+++ b/movr.py
@@ -197,6 +197,8 @@ class MovR:
         queries_to_run["pk_alters"].append("ALTER TABLE vehicles ALTER PRIMARY KEY USING COLUMNS (city, id);")
         queries_to_run["pk_alters"].append("ALTER TABLE user_promo_codes ALTER PRIMARY KEY USING COLUMNS (city, user_id, code);")
 
+        # users
+        queries_to_run["fk_alters"].append("DROP INDEX users_city_idx;")
         # vehicles
         queries_to_run["fk_alters"].append("ALTER TABLE vehicles DROP CONSTRAINT fk_owner_id_ref_users;")
         #foreign key requires an existing index on columns

--- a/movr.py
+++ b/movr.py
@@ -202,6 +202,7 @@ class MovR:
         #foreign key requires an existing index on columns
         queries_to_run["fk_alters"].append("CREATE INDEX ON vehicles (city, owner_id);")
         queries_to_run["fk_alters"].append("DROP INDEX vehicles_auto_index_fk_owner_id_ref_users;")
+        queries_to_run["fk_alters"].append("DROP INDEX vehicles_city_idx;")
         queries_to_run["fk_alters"].append(
             "ALTER TABLE vehicles ADD CONSTRAINT fk_owner_id_ref_users_mr FOREIGN KEY (city, owner_id) REFERENCES users (city,id);")
 


### PR DESCRIPTION
This update allows MovR to start in a single region (default) or multi-region deployment. The new `configure-multi-region` command enables no-downtime migrations from single region to multi-region.

This update relies on features in CockroachDB 20.1 

An image is available on my docker hub. 
Ex: `docker run -it --rm natestewart/movr:20.03.1 --url "postgres://root@docker.for.mac.localhost:26257/movr?sslmode=disable" {load, run}`