### PR TITLE
Simplifed multi-region schema with REGIONAL BY ROW tables

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,18 +1,13 @@
 
 from sqlalchemy.ext.declarative import declarative_base
-#from sqlalchemy.orm import relationship
 from sqlalchemy import Column, String, DateTime, Integer, Float, \
-    PrimaryKeyConstraint, ForeignKeyConstraint, CheckConstraint
+    PrimaryKeyConstraint, ForeignKeyConstraint
 from sqlalchemy.dialects.postgresql import UUID, JSONB
-import sqlalchemy.types as types
+from sqlalchemy.types import DECIMAL
 
 import datetime
 
 from generators import MovRGenerator
-
-# @todo: restore FKs and "relationship' functionality after this is fixed: https://github.com/cockroachdb/cockroach/issues/36859
-
-# default to the single region schema and dynamically make multi-region based on command line args.
 
 Base = declarative_base()
 
@@ -20,7 +15,7 @@ Base = declarative_base()
 class User(Base):
     __tablename__ = 'users'
     id = Column(UUID, primary_key=True, default=MovRGenerator.generate_uuid)
-    city = Column(String, nullable=False, index=True)
+    city = Column(String, nullable=False)
     name = Column(String)
     address = Column(String)
     credit_card = Column(String)
@@ -28,20 +23,17 @@ class User(Base):
     def __repr__(self):
         return "<User(city='%s', id='%s', name='%s')>" % (self.city, self.id, self.name)
 
-# @todo: sqlalchemy fails silently if compound fks are in the wrong order.
-
-
 class Ride(Base):
     __tablename__ = 'rides'
     id = Column(UUID, primary_key=True, default=MovRGenerator.generate_uuid)
-    city = Column(String, nullable=False, index=True)
+    city = Column(String, nullable=False)
     rider_id = Column(UUID)
     vehicle_id = Column(UUID)
     start_address = Column(String)
     end_address = Column(String)
     start_time = Column(DateTime, default=datetime.datetime.now)
     end_time = Column(DateTime)
-    revenue = Column(types.DECIMAL(10, 2))
+    revenue = Column(DECIMAL(10, 2))
     __table_args__ = (ForeignKeyConstraint(
         [rider_id], ["users.id"], name='fk_rider_id_ref_users'),)
     __table_args__ = (ForeignKeyConstraint(
@@ -70,7 +62,7 @@ class VehicleLocationHistory(Base):
 class Vehicle(Base):
     __tablename__ = 'vehicles'
     id = Column(UUID, primary_key=True, default=MovRGenerator.generate_uuid)
-    city = Column(String, nullable=False, index=True)
+    city = Column(String, nullable=False)
     type = Column(String)
     owner_id = Column(UUID)
     creation_time = Column(DateTime, default=datetime.datetime.now)
@@ -79,7 +71,6 @@ class Vehicle(Base):
     ext = Column(JSONB)
     __table_args__ = (ForeignKeyConstraint(
         [owner_id], ["users.id"], name='fk_owner_id_ref_users'),)
-    # check performance since removing indexes
 
     def __repr__(self):
         return "<Vehicle(city='%s', id='%s', type='%s', status='%s', ext='%s')>" % (self.city, self.id, self.type, self.status, self.ext)


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/movr/issues/106.

This PR includes the following changes:

- `REGIONAL BY ROW AS <region>` tables now use `REGIONAL BY ROW` and hidden `crdb_region` column.
- (If the table is already populated) `crdb_region` values in existing rows are updated based on the value of the `city` column.

Note the following:

- If rows already exist in the database (pre-multi-region), there must be a column that indicates region (e.g., `city`) that we can use to update the `crdb_region` values in existing rows. Without such a column, all existing rows will be in the primary region.
- To update `crdb_region` values in existing rows, SQLAlchemy uses a `Column` object of SQLAlchemy `String` type. This works because SQLAlchemy isn't persisting the `crdb_column` column to the database (cockroachdb adds the column when the multi-region schema changes happen); it's only updating the column values. And I believe `crdb_region` is just a `STRING` `ENUM` in cockroachdb.
- The first schema change (`ALTER DATABASE PRIMARY REGION`) is much slower when executed through SQLAlchemy (~4 minutes) than when executed through the shell (~7 seconds). I'm hopeful that using a proper schema migration tool will improve this.