### PR TITLE
Updated crdb_region type to use types.Enum

### DIFF
--- a/movr.py
+++ b/movr.py
@@ -2,6 +2,7 @@ from sqlalchemy import create_engine, text, Column, String
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.sql import column
+from sqlalchemy.types import Enum
 from models import Base, User, Vehicle, Ride, VehicleLocationHistory, PromoCode, UserPromoCode
 from cockroachdb.sqlalchemy import run_transaction
 from generators import MovRGenerator
@@ -222,8 +223,11 @@ class MovR:
 
     def update_region(self, table, region, cities):
 
+        region_list = self.get_regions()
+        region_enum = Enum(*region_list, name='crdb_internal_region', create_type=False, native_enum=False)
+
         def update_region_helper(session, table, region, cities):
-            crdb_region = Column('crdb_region', String)
+            crdb_region = Column('crdb_region', region_enum)
             table.append_column(crdb_region)
             query = table.update().where(column('city').in_(cities)
                                          ).values({crdb_region: region})


### PR DESCRIPTION
This PR includes the following change:

-  `update_region` helper now uses the SQLAlchemy `types` library to define the `crdb_region` Enum.